### PR TITLE
Update pybind version to v2.10.1 to support python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python_tag: [cp36, cp37, cp38, cp39, cp310]
+        python_tag: [cp36, cp37, cp38, cp39, cp310, cp311]
         include:
           - os: windows-latest
             os_tag: win_amd64
@@ -82,7 +82,7 @@ jobs:
   wheel-apple_silicon:
     strategy:
       matrix:
-        python_tag: [cp38, cp39, cp310]
+        python_tag: [cp38, cp39, cp310, cp311]
         macos_arch: [arm64, universal2]
 
     name: "wheel: ${{ matrix.python_tag }}-macosx_${{ matrix.macos_arch }}"

--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries',
     ],

--- a/tree/CMakeLists.txt
+++ b/tree/CMakeLists.txt
@@ -51,7 +51,7 @@ if(APPLE)
 endif()
 
 # Fetch pybind to be able to use pybind11_add_module symbol.
-set(PYBIND_VER v2.6.2)
+set(PYBIND_VER v2.10.1)
 include(FetchContent)
 FetchContent_Declare(
   pybind11


### PR DESCRIPTION
With pybind v2.6.2, dm-tree cannot be built on python 3.11.

Pybind v2.10.0 has support for python 3.11, so we upgrade the pybind
dependency version so that dm-tree can be built.


### For early adapters who'd like to install this PR version on python 3.11 until gets merged:

```
python3.11 -m pip install 'dm-tree @ git+https://github.com/deepmind/tree@refs/pull/91/head'
```