### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           CIBW_FREE_THREADED_SUPPORT: True
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_SKIP: "*musllinux* *i686* *win32* *t-win*"
-          CIBW_TEST_COMMAND: pytest --pyargs tree
+          CIBW_TEST_COMMAND: pytest --pyargs tree --import-mode=importlib
           CIBW_TEST_REQUIRES: pytest
           MAKEFLAGS: "-j$(nproc)"
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,9 @@ class BuildCMakeExtension(build_ext.build_ext):
         f'-DPython3_EXECUTABLE={sys.executable}',
         f'-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extension_dir}',
         f'-DCMAKE_BUILD_TYPE={build_cfg}'
+        # Add options to use distros libraries
+        f'-DUSE_SYSTEM_ABSEIL={"ON" if os.environ.get("USE_SYSTEM_ABSEIL") else "OFF"}',
+        f'-DUSE_SYSTEM_PYBIND11={"ON" if os.environ.get("USE_SYSTEM_PYBIND11") else "OFF"}'
     ]
     if platform.system() != 'Windows':
       cmake_args.extend([

--- a/tree/CMakeLists.txt
+++ b/tree/CMakeLists.txt
@@ -89,8 +89,8 @@ endif()
 
 FetchContent_Declare(
   absl
-  URL         ${ABSEIL_REPO}/archive/refs/tags/20220623.2.tar.gz
-  URL_HASH    SHA256=773652c0fc276bcd5c461668dc112d0e3b6cde499600bfe3499c5fdda4ed4a5b
+  URL         ${ABSEIL_REPO}/archive/refs/tags/20250127.1.tar.gz
+  URL_HASH    SHA256=b396401fd29e2e679cace77867481d388c807671dc2acc602a0259eeb79b7811
   CMAKE_ARGS  ${ABSEIL_CMAKE_ARGS}
   EXCLUDE_FROM_ALL
   ${ABSEIL_FIND_PACKAGE_ARGS})
@@ -103,8 +103,8 @@ endif()
 
 FetchContent_Declare(
   pybind11
-  URL       https://github.com/pybind/pybind11/archive/refs/tags/v2.10.1.tar.gz
-  URL_HASH  SHA256=111014b516b625083bef701df7880f78c2243835abdb263065b6b59b960b6bad
+  URL       https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz
+  URL_HASH  SHA256=e08cb87f4773da97fa7b5f035de8763abc656d87d5773e62f6da0587d1f0ec20
   ${PYBIND11_FIND_PACKAGE_ARGS})
 
 FetchContent_MakeAvailable(absl pybind11)


### PR DESCRIPTION
This PR will fix the build process occurred by CMake Policy Minimum version by the new CMake version >=4 by updating abseil-cpp and pybind11.
It also add the ability to make user choose between abseil-cpp and pybind11 provided from system or downloaded from repository.
This PR should close this [issue](https://github.com/google-deepmind/tree/issues/130).